### PR TITLE
Allow for arguments in result() method

### DIFF
--- a/pytest_bigquery_mock/plugin.py
+++ b/pytest_bigquery_mock/plugin.py
@@ -31,7 +31,7 @@ class FakeQuery:
     def add_done_callback(self, func):
         func(self)
 
-    def result(self):
+    def result(self, *args, **kwargs):
         return self.row_iterator
 
     def to_dataframe(self):


### PR DESCRIPTION
QueryJob.result() allows passing arguments. My specific use case is the timeout argument. With this change the same BQ works in production and testing.