### PR TITLE
Feature/mock load table from dataframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ plugins = ["pytest-bigquery-mock"]
 
 This allows you to use the `bq_client_mock` fixture in your pytest tests.
 
-```
+
+## Example Usage:
+
+### Mocking the client query functionality:
+
+```python
 def function_that_calls_bigquery(bq_client):
     row_iter = bq_client.query("SELECT * FROM table").result()
     return row_iter
@@ -52,4 +57,35 @@ def test_function_that_calls_bigquery(bq_client_mock):
     for row, expected_row in zip(row_iter, expected_row_dicts):
         assert dict(row) == expected_row
 
+```
+
+### Mocking the load_table functionality
+
+Supports the following load_table operations:
+* `load_table_from_dataframe`
+* `load_table_from_json`
+* `load_table_from_file`
+* `load_table_from_uri`
+
+```python
+def function_that_calls_bigquery(bq_client, df):
+    load_job = bq_client.load_table_from_dataframe(df, "table_ref")
+    print(load_job.state)
+    return load_job.done()
+
+
+# Pass the final states you want the mock load_table job to reach as an argument
+@pytest.mark.bq_load_table_state(done_state=True, exist_state=True, running_state=False)
+def test_function_that_calls_bigquery(bq_client_mock):
+
+    mock_df_row_dicts = [
+        {"id_row": 1, "name": "Alice"},
+        {"id_row": 2, "name": "Pete"},
+        {"id_row": 3, "name": "Steven"},
+    ]
+
+    mock_df = pd.DataFrame(mock_df_row_dicts)
+
+    done = function_that_calls_bigquery(bq_client_mock, df)
+    assert done
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+markers = [
+    "bq_query_return_data",
+    "bq_load_table_state"
+]

--- a/pytest_bigquery_mock/plugin.py
+++ b/pytest_bigquery_mock/plugin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pandas as pd
 import pytest
 from google.cloud.bigquery.table import Row
@@ -5,14 +7,14 @@ from google.cloud.bigquery.table import Row
 
 job_counter = 0
 
+
 class FakeRowIterator:
     def __init__(self, rows):
         self._rows = rows
         self.total_rows = len(rows)
 
     def __iter__(self):
-        for row in self._rows:
-            yield row
+        yield from self._rows
 
     def to_dataframe(self):
         df = pd.DataFrame(columns=list(self._rows[0].keys()))
@@ -36,32 +38,124 @@ class FakeQuery:
 
     def to_dataframe(self):
         return self.result().to_dataframe()
+        
+
+class FakeLoadJob:
+    def __init__(
+        self,
+        cancel_state=None,
+        done_state=True,
+        exist_state=True,
+        running_state=False,
+        errors=None,
+        **kwargs,
+    ):
+        """Creates an instance of a fake LoadJob
+        (see https://cloud.google.com/python/docs/reference/bigquery/latest/google.cloud.bigquery.job.LoadJob)
+        with mock LoadJob states set by class attributes.
+
+        Args:
+            cancel_state (bool | None, optional): Mock job cancel state. Defaults to None.
+            done_state (bool, optional): Mock job done state. Defaults to True.
+            exist_state (bool, optional): Mock job exist state. Defaults to True.
+            running_state (bool, optional): Mock job running state. Should be False if
+                done_state is True. Defaults to False.
+            errors (List[Exception], optional): List of mock errors raised by job.
+                Defaults to None.
+        """
+        if done_state and running_state:
+            raise ValueError("'done_state' must be False if 'running_state' is True.")
+        self.cancel_state = cancel_state
+        self.done_state = done_state
+        self.exist_state = exist_state
+        self.running_state = running_state
+        self.errors = errors
+        self.__dict__.update(kwargs)
+        self.state = self._get_state()
+
+    def _get_state(self):
+        if self.done_state:
+            return "DONE"
+        elif self.running_state:
+            return "RUNNING"
+        else:
+            return "FAILURE"
+
+    def add_done_callback(self, func):
+        func(self)
+
+    def cancel(self):
+        return self.cancel_state
+
+    def cancelled(self):
+        """Always returns False as per the original LoadJob
+        """
+        return False
+
+    def done(self):
+        return self.done_state
+
+    def exception(self):
+        return self.errors
+
+    def exists(self):
+        return self.exist_state
+
+    def result(self):
+        return FakeLoadJob()
+
+    def running(self):
+        return self.running_state
+
+
+def patch_query(mock_bq_client, query_data):
+    def mock_client_query(query, *args, **kwargs):
+        for qry_data in query_data:
+            if query == qry_data.get("query"):
+                columns = {k: v for v, k in enumerate(qry_data["table"]["columns"])}
+                rows = [
+                    Row(row_data, columns) for row_data in qry_data["table"]["rows"]
+                ]
+                row_iter = FakeRowIterator(rows)
+                query = FakeQuery(row_iter)
+                return query
+
+    mock_bq_client.query = mock_client_query
+
+    return mock_bq_client
+
+
+def patch_load_table(mock_bq_client, **kwargs):
+    """Patches all load_table_from_<src> methods in the bigquery
+    client.
+    """
+    fake_load_job = FakeLoadJob(**kwargs)
+
+    def mock_load_table(src, destination, *args, **kwargs):
+        return fake_load_job
+
+    mock_bq_client.load_table_from_dataframe = mock_load_table
+    mock_bq_client.load_table_from_json = mock_load_table
+    mock_bq_client.load_table_from_file = mock_load_table
+    mock_bq_client.load_table_from_uri = mock_load_table
+
+    return mock_bq_client
 
 
 @pytest.fixture
 def bq_client_mock(request, mocker):
 
-    marker = request.node.get_closest_marker("bq_query_return_data")
-    if marker is None:
-        data = None
-    else:
-        data = marker.args[0]
+    mock_bq_client = mocker.patch("google.cloud.bigquery.client.Client")
 
-    if data:
+    query_marker = request.node.get_closest_marker("bq_query_return_data")
+    query_data = None if query_marker is None else query_marker.args[0]
 
-        def mock_client_query(query, *args, **kwargs):
-            for qry_data in data:
-                if query == qry_data.get("query"):
-                    columns = {k: v for v, k in enumerate(qry_data["table"]["columns"])}
-                    rows = [
-                        Row(row_data, columns) for row_data in qry_data["table"]["rows"]
-                    ]
-                    row_iter = FakeRowIterator(rows)
-                    query = FakeQuery(row_iter)
-                    return query
+    load_table_marker = request.node.get_closest_marker("bq_load_table_state")
+    load_table_states = None if load_table_marker is None else load_table_marker.kwargs
 
-        mock_bq_client = mocker.patch("google.cloud.bigquery.client.Client")
-        mock_bq_client.query = mock_client_query
-        return mock_bq_client
-    else:
-        return mocker.MagicMock()
+    if query_data:
+        mock_bq_client = patch_query(mock_bq_client, query_data)
+    if load_table_states:
+        mock_bq_client = patch_load_table(mock_bq_client, **load_table_states)
+
+    return mock_bq_client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+from pytest_bigquery_mock.plugin import bq_client_mock
+
+plugins = ["pytest-bigquery-mock"]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,58 @@
+import pytest
+import pandas as pd
+
+
+def query_function(bq_client):
+    row_iter = bq_client.query("SELECT * FROM table").result()
+    return row_iter
+
+
+def load_table_function(bq_client, df):
+    load_job = bq_client.load_table_from_dataframe(df, "a_table")
+    print(load_job.state)
+    return load_job.done()
+
+
+@pytest.mark.bq_load_table_state(done_state=True, exist_state=True, running_state=False)
+def test_function_that_calls_bigquery_v2(bq_client_mock):
+
+    expected_row_dicts = [
+        {"id_row": 1, "name": "Alice"},
+        {"id_row": 2, "name": "Pete"},
+        {"id_row": 3, "name": "Steven"},
+    ]
+
+    df = pd.DataFrame(expected_row_dicts)
+
+    done = load_table_function(bq_client_mock, df)
+    assert done
+
+
+@pytest.mark.bq_query_return_data(
+    [
+        {
+            "query": "SELECT * FROM table",
+            "table": {
+                "columns": [
+                    "id_row",
+                    "name",
+                ],
+                "rows": [
+                    [1, "Alice"],
+                    [2, "Pete"],
+                    [3, "Steven"],
+                ],
+            },
+        },
+    ]
+)
+def test_function_that_calls_bigquery(bq_client_mock):
+    row_iter = query_function(bq_client_mock)
+
+    expected_row_dicts = [
+        {"id_row": 1, "name": "Alice"},
+        {"id_row": 2, "name": "Pete"},
+        {"id_row": 3, "name": "Steven"},
+    ]
+    for row, expected_row in zip(row_iter, expected_row_dicts):
+        assert dict(row) == expected_row

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -13,21 +13,6 @@ def load_table_function(bq_client, df):
     return load_job.done()
 
 
-@pytest.mark.bq_load_table_state(done_state=True, exist_state=True, running_state=False)
-def test_function_that_calls_bigquery_v2(bq_client_mock):
-
-    expected_row_dicts = [
-        {"id_row": 1, "name": "Alice"},
-        {"id_row": 2, "name": "Pete"},
-        {"id_row": 3, "name": "Steven"},
-    ]
-
-    df = pd.DataFrame(expected_row_dicts)
-
-    done = load_table_function(bq_client_mock, df)
-    assert done
-
-
 @pytest.mark.bq_query_return_data(
     [
         {
@@ -46,7 +31,7 @@ def test_function_that_calls_bigquery_v2(bq_client_mock):
         },
     ]
 )
-def test_function_that_calls_bigquery(bq_client_mock):
+def test_query_function(bq_client_mock):
     row_iter = query_function(bq_client_mock)
 
     expected_row_dicts = [
@@ -56,3 +41,18 @@ def test_function_that_calls_bigquery(bq_client_mock):
     ]
     for row, expected_row in zip(row_iter, expected_row_dicts):
         assert dict(row) == expected_row
+
+
+@pytest.mark.bq_load_table_state(done_state=True, exist_state=True, running_state=False)
+def test_load_table_function(bq_client_mock):
+
+    mock_df_row_dicts = [
+        {"id_row": 1, "name": "Alice"},
+        {"id_row": 2, "name": "Pete"},
+        {"id_row": 3, "name": "Steven"},
+    ]
+
+    df = pd.DataFrame(mock_df_row_dicts)
+
+    done = load_table_function(bq_client_mock, df)
+    assert done


### PR DESCRIPTION
Not sure if this repo was open to being expanded with more functionality, but have added some additional mocking functionality I've used in previous projects that have used BigQuery.

**Summary of Changes**

- Added a patch_load_table function that is used to patch all the load_table methods in Bigquery (e.g. load_table_from_dataframe, load_table_from_file). The method returns a mock LoadJob object where the final state reached by the job gets set by the pytest mark
- Added some tests to call the different plugin methods and make it easier to keep track of any plugin changes
- Updated the README to include code examples for the load_table mocking functions